### PR TITLE
Added proxy support and more verbose error logging.

### DIFF
--- a/lib/ask-stack-api-client.coffee
+++ b/lib/ask-stack-api-client.coffee
@@ -33,6 +33,8 @@ class AskStackApiClient
       headers:
         'User-Agent': 'Atom-Ask-Stack'
 
+    options.proxy = process.env.http_proxy if process.env.http_proxy?
+
     request options, (error, res, body) ->
       if not error and res.statusCode is 200
         try
@@ -43,7 +45,7 @@ class AskStackApiClient
         finally
           callback(response)
       else
-        console.log "Error: #{error}"
+        console.log "Error: #{error}", "Result: ", res
         response = null
 
   @resetInputs: ->


### PR DESCRIPTION
If a user has defined `http_proxy` environment variable, then set the corresponding `proxy` option in the HTTP request. This allows users behind a proxy server to use this package.

In addition, added more verbose error logging by including the HTTP response object, `res`, in the console output. While testing this new functionality, I encountered an error from stack exchange due to rate limiting of requests coming from the corporate proxy server. This was only apparent after examining the HTTP response object, which contained the true reason for failure, so I've now included the response object in the console logging.
