### PR TITLE
Alter workspace tags

### DIFF
--- a/keymaps/ask-stack.cson
+++ b/keymaps/ask-stack.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom.workspace':
   'ctrl-alt-a': 'ask-stack:ask-question'


### PR DESCRIPTION
Fixes deprecation error warning:

keymaps/ask-stack.cson
     Use the `atom-workspace` tag instead of the `workspace` class.
