### PR TITLE
Update ask-stack.cson

### DIFF
--- a/keymaps/ask-stack.cson
+++ b/keymaps/ask-stack.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'atom.workspace':
+'atom-workspace':
   'ctrl-alt-a': 'ask-stack:ask-question'


### PR DESCRIPTION
> keymaps/ask-stack.cson
> Use the 'atom-workspace' tag instead of the 'workspace' class.

typo corrected