### PR TITLE
Resolving deprecated notifications from Ask-Stack-Atom for next API 1.0

### DIFF
--- a/lib/ask-stack-result-view.coffee
+++ b/lib/ask-stack-result-view.coffee
@@ -28,6 +28,9 @@ class AskStackResultView extends ScrollView
   getIconName: ->
     'three-bars'
 
+  onDidChangeTitle: -> 
+  onDidChangeModified: -> 
+
   handleEvents: ->
     @subscribe this, 'core:move-up', => @scrollUp()
     @subscribe this, 'core:move-down', => @scrollDown()
@@ -167,10 +170,11 @@ class AskStackResultView extends ScrollView
     })
     if type == 'Insert'
       $(btn).click (event) ->
-        code = $(this).next().next('pre').text()
+        code = $(this).next('pre').text()
         if code != undefined
           atom.workspace.activatePreviousPane()
-          editor = atom.workspace.activePaneItem
+          # editor = atom.workspace.activePaneItem
+          editor = atom.workspace.getActivePaneItem()
           editor.insertText(code)
 
     return btn

--- a/lib/ask-stack-view.coffee
+++ b/lib/ask-stack-view.coffee
@@ -1,6 +1,6 @@
 url = require 'url'
 
-{CompositeDisposable} = require 'atom'
+{CompositeDisposable} = require 'event-kit'
 {TextEditorView, View} = require 'atom-space-pen-views'
 
 AskStack = require './ask-stack'
@@ -19,8 +19,10 @@ class AskStackView extends View
             @subview 'questionField', new TextEditorView(mini:true, placeholderText: 'Question (eg. Sort array)')
             @subview 'tagsField', new TextEditorView(mini:true, placeholderText: 'Language / Tags (eg. Ruby;Rails)')
             @div class: 'pull-right', =>
+              @br()
               @button outlet: 'askButton', class: 'btn btn-primary', ' Ask! '
             @div class: 'pull-left', =>
+              @br()
               @label 'Sort by:'
               @br()
               @label for: 'relevance', class: 'radio-label', 'Relevance: '
@@ -31,13 +33,12 @@ class AskStackView extends View
             @span class: 'loading loading-spinner-medium'
 
   initialize: (serializeState) ->
-    @handleEvents()
-
     @subscriptions = new CompositeDisposable
-
     @subscriptions.add atom.commands.add 'atom-workspace',
       'ask-stack:ask-question', => @presentPanel()
-
+    
+    @handleEvents() 
+    
     @autoDetectObserveSubscription =
       atom.config.observe 'ask-stack.autoDetectLanguage', (autoDetect) =>
         _this.tagsField.setText("") unless autoDetect
@@ -64,14 +65,19 @@ class AskStackView extends View
     @panel.hide()
     @.focusout()
 
+  onDidChangeTitle: -> 
+  onDidChangeModified: -> 
+
   handleEvents: ->
     @askButton.on 'click', => @askStackRequest()
 
-    @questionField.on 'core:confirm', => @askStackRequest()
-    @questionField.on 'core:cancel', => @hideView()
+    @subscriptions.add atom.commands.add @questionField.element,
+      'core:confirm': => @askStackRequest()
+      'core:cancel': => @hideView()
 
-    @tagsField.on 'core:confirm', => @askStackRequest()
-    @tagsField.on 'core:cancel', => @hideView()
+    @subscriptions.add atom.commands.add @tagsField.element,
+      'core:confirm': => @askStackRequest()
+      'core:cancel': => @hideView()
 
   presentPanel: ->
     #atom.workspaceView.append(this)

--- a/lib/ask-stack.coffee
+++ b/lib/ask-stack.coffee
@@ -1,7 +1,7 @@
 AskStackView = require './ask-stack-view'
 
 module.exports =
-  configDefaults:
+  config:
     autoDetectLanguage: true
   askStackView: null
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "main": "./lib/ask-stack",
   "version": "1.1.0",
   "description": "Quickly get answers and code samples from Stack Overflow in Atom",
-  "activationEvents": [
-    "ask-stack:ask-question"
-  ],
+  "activationCommands": {
+   "atom-text-editor": ["ask-stack:ask-question"]
+ },
   "repository": "https://github.com/Chris911/Ask-Stack-Atom",
   "license": "MIT",
   "author": {
@@ -18,6 +18,7 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.3",
     "request": "2.x",
-    "highlight.js": "8.x"
+    "highlight.js": "8.x",
+    "event-kit": "~1.2.0"
   }
 }


### PR DESCRIPTION
- add config parameters instead of configDefaults.
- add onDidChangeTitle and  onDidChangeModified events.
- change item.on events to use atom.commands.add events and add event-kit module.
- add getActivePaneItem instead of activePaneItem.
- add some br's in main panel view.
- add activationCommands instead of activationEvents.
- detected problem with paste code from results panel: change code = $(this).next('pre').text() to code = $(this).next('pre').text().