### PR TITLE
Add more information to the result page

### DIFF
--- a/lib/ask-stack-result-view.coffee
+++ b/lib/ask-stack-result-view.coffee
@@ -55,14 +55,26 @@ class AskStackResultView extends ScrollView
   renderQuestionHeader: (question) ->
     # Decode title html entities
     title = $('<div/>').html(question['title']).text();
+    # Decode display_name html entities
+    display_name = $('<textarea />').html(question['owner'].display_name).text();
     questionHeader = $$$ ->
       @div id: question['question_id'], class: 'ui-result', =>
         @h2 class: 'title', =>
           @a href: question['link'], class: 'underline title-string', title
-          @div class: 'score', =>
+          # Added tooltip to explain that the value is the number of votes
+          @div class: 'score', title: question['score'] + ' Votes', =>
             @p question['score']
+          # Added a new badge for showing the total number of answers, and a tooltip to explain that the value is the number of answers
+          @div class: 'answers', title: question['answer_count'] + ' Answers', =>
+            @p question['answer_count']
+          # Added a check mark to show that the question has an accepted answer
+          @div class: 'is-accepted', =>
+            @p class: 'icon icon-check', title: 'This question has an accepted answer' if question['accepted_answer_id']
         @div class: 'created', =>
           @text new Date(question['creation_date'] * 1000).toLocaleString()
+          # Added credits of who asked the question, with a link back to their profile
+          @text ' - asked by '
+          @a href: question['owner'].link, display_name
         @div class: 'tags', =>
           for tag in question['tags']
             @span class: 'label label-info', tag
@@ -135,13 +147,24 @@ class AskStackResultView extends ScrollView
         btn.text('Show Less')
 
   renderAnswerBody: (answer, question_id) ->
+    # Decode display_name html entities
+    display_name = $('<textarea/>').html(answer['owner'].display_name).text();
     answerHtml = $$$ ->
       @div =>
         @a href: answer['link'], =>
           @span class: 'answer-link', '➚'
         @span class: 'label label-success', 'Accepted' if answer['is_accepted']
-        @div class: 'score answer', =>
+        # Added tooltip to explain that the value is the number of votes
+        @div class: 'score answer', title: answer['score'] + ' Votes', =>
           @p answer['score']
+        # Added a check mark to show that this is the accepted answer
+        @div class: 'score is-accepted', =>
+          @p class: 'icon icon-check', title: 'Accepted answer' if answer['is_accepted']
+        # Added credits of who answered the question, with a link back to their profile, and also when it was answered
+        @div class: 'created', =>
+          @text new Date(answer['creation_date'] * 1000).toLocaleString()
+          @text ' - answered by '
+          @a href: answer['owner'].link, display_name
 
     $("#answers-#{question_id}").append($(answerHtml).append(answer['body']))
 

--- a/lib/ask-stack-view.coffee
+++ b/lib/ask-stack-view.coffee
@@ -36,9 +36,9 @@ class AskStackView extends View
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.commands.add 'atom-workspace',
       'ask-stack:ask-question', => @presentPanel()
-    
-    @handleEvents() 
-    
+
+    @handleEvents()
+
     @autoDetectObserveSubscription =
       atom.config.observe 'ask-stack.autoDetectLanguage', (autoDetect) =>
         _this.tagsField.setText("") unless autoDetect
@@ -65,8 +65,8 @@ class AskStackView extends View
     @panel.hide()
     @.focusout()
 
-  onDidChangeTitle: -> 
-  onDidChangeModified: -> 
+  onDidChangeTitle: ->
+  onDidChangeModified: ->
 
   handleEvents: ->
     @askButton.on 'click', => @askStackRequest()
@@ -106,7 +106,7 @@ class AskStackView extends View
   showResults: (answersJson) ->
     uri = 'ask-stack://result-view'
 
-    atom.workspace.open(uri, split: 'right', searchAllPanes: true).done (askStackResultView) ->
+    atom.workspace.open(uri, split: 'right', searchAllPanes: true).then (askStackResultView) ->
       if askStackResultView instanceof AskStackResultView
         askStackResultView.renderAnswers(answersJson)
         atom.workspace.activatePreviousPane()

--- a/styles/ask-stack.less
+++ b/styles/ask-stack.less
@@ -171,13 +171,41 @@
       position: absolute;
       left: -60px;
       top: 1px;
-      background: green;
+      background: white;
       border-radius:5px;
       width:50px;
       height:25px;
     }
     .score p {
-      color: #fff;
+      color: gray;
+      text-align: center;
+      font-size: 0.8em;
+    }
+    .answers {
+      position: absolute;
+      left: -60px;
+      top: 31px;
+      background: green;
+      border-radius:5px;
+      width:50px;
+      height:25px;
+    }
+    .answers p {
+      color: greenyellow;
+      text-align: center;
+      font-size: 0.8em;
+    }
+    .is-accepted {
+      position: absolute;
+      left: -60px;
+      top: 61px;
+      background: transparent;
+      border-radius:5px;
+      width:50px;
+      height:25px;
+    }
+    .is-accepted p {
+      color: black;
       text-align: center;
       font-size: 0.8em;
     }
@@ -189,14 +217,36 @@
     position: relative;
     left: -60px;
     top: 1px;
-    background: green;
+    background: white;
     border-radius:5px;
     width:50px;
     height:25px;
-    color: #fff;
+    color: grey;
+    //font-weight: bold;
     text-align: center;
     font-size:1.2em;
   }
+
+  .score.is-accepted {
+    font-family: 'Lucida Grande', 'Segoe UI', sans-serif;
+    margin-top: -15px;
+    position: relative;
+    left: -60px;
+    top: 21px;
+    background: transparent;
+    border-radius:5px;
+    width:50px;
+    height:25px;
+    color: green;
+    text-align: center;
+    font-size:1.2em;
+  }
+
+  .answer-navigation div .created {
+    background: peachpuff;
+    border-radius: 5px;
+    text-align: center;
+}
 
   .answer-link {
     position: relative;


### PR DESCRIPTION
I have added more information to the displayed results:
 * Add tooltips (in the form of html attr title) to explain the badges.
 * Add number of answers available for a question.
 * Add a check mark to outline if the question has an accepted answer or not.
 * Add a check mark to outline which answer has been accepted.
 * Add credits of who asked the question next to the date (with link back to profile).
 * Add credits of who answered the question (with link back to profile) and the date they answered it on the answer tab.
 * Add new CSS rules for the new elements (as mentioned above).
 * Update the existing CSS rules to better reflect the information presented.

Please see attached screenshots:

![1](https://cloud.githubusercontent.com/assets/115112/12541271/bb071184-c30c-11e5-8a46-06827d7a2928.png)

![2](https://cloud.githubusercontent.com/assets/115112/12541311/6dc29c12-c30d-11e5-9d0f-9f7bd451082c.png)

![3](https://cloud.githubusercontent.com/assets/115112/12541389/6774c5fa-c30e-11e5-93d0-31777f1cda81.png)

![4](https://cloud.githubusercontent.com/assets/115112/12541403/9d7cc6d4-c30e-11e5-9dfd-2d671ca0cc8c.png)

![5](https://cloud.githubusercontent.com/assets/115112/12541343/f040ce34-c30d-11e5-941b-586f6efff3f7.png)

![6](https://cloud.githubusercontent.com/assets/115112/12541429/dcb216b0-c30e-11e5-9109-b05077734fa5.png)
