### PR TITLE
Fix bug where a long url (html a tag) links would roll outside of the container.

### DIFF
--- a/styles/ask-stack.less
+++ b/styles/ask-stack.less
@@ -94,7 +94,8 @@
   }
 
   a {
-    color: #428bca
+    color: #428bca;
+    word-wrap: break-word;
   }
 
   a.underline {


### PR DESCRIPTION
I found a minor bug where long url's would continue out of its container (making it unreadable) instead of wrapping within it.