### PR TITLE
Fix spec issues caused by deprecated calls.

### DIFF
--- a/spec/ask-stack-result-view-spec.coffee
+++ b/spec/ask-stack-result-view-spec.coffee
@@ -1,13 +1,9 @@
-{$, EditorView, WorkspaceView} = require 'atom'
-
 AskStackResultView = require '../lib/ask-stack-result-view'
 
 describe "AskStackResultView", ->
   resultView = null
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
-
     resultView = new AskStackResultView()
 
   describe "when search returns no result", ->

--- a/spec/ask-stack-view-spec.coffee
+++ b/spec/ask-stack-view-spec.coffee
@@ -1,12 +1,9 @@
 AskStackView = require '../lib/ask-stack-view'
-{WorkspaceView} = require 'atom'
 
 describe "AskStackView", ->
   askStackView = null
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
-
     askStackView = new AskStackView()
 
   describe "when the panel is presented", ->


### PR DESCRIPTION
I tried to also fix the spec in file `spec/ask-stack-spec.coffee` too, however all the documented ways I found seem to not work. Not entirely sure why.

Here's what I last tried to fix it but for some reason no amount of changing how to find if `.ask-stack` was added to the DOM worked for me, presumably because it was not being added properly...

```
# {$, EditorView, WorkspaceView} = require 'atom'
{$} = require 'atom-space-pen-views'

AskStack = require '../lib/ask-stack'

# Use the command `window:run-package-specs` (cmd-alt-ctrl-p) to run specs.
#
# To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
# or `fdescribe`). Remove the `f` to unfocus the block.

describe "AskStack", ->
  [activationPromise, editor] = []

  getWorkspaceView = -> atom.views.getView(atom.workspace)
  getEditorView = -> atom.views.getView(atom.workspace.getActiveTextEditor())

  beforeEach ->
    activationPromise = atom.packages.activatePackage('ask-stack')
    jasmine.attachToDOM(getWorkspaceView())

  describe "when the ask-stack:ask-question event is triggered", ->
    it "attaches the view", ->
      expect($(getWorkspaceView()).find('.ask-stack')).not.toExist()

      # This is an activation event, triggering it will cause the package to be
      # activated.
      atom.commands.dispatch(getWorkspaceView(), 'ask-stack:ask-question')

      expect($(getWorkspaceView()).find('.ask-stack')).toExist()
```
